### PR TITLE
Added html option to Config

### DIFF
--- a/client/s-alert-template.html
+++ b/client/s-alert-template.html
@@ -10,7 +10,7 @@
     {{else}}
         <div class="s-alert-box s-alert-{{condition}} s-alert-{{position}} s-alert-effect-{{effect}} s-alert-show" id="{{_id}}">
             <div class="s-alert-box-inner">
-                <p>{{message}}</p>
+                <p>{{#if isHtml}}{{{message}}}{{else}}{{message}}{{/if}}</p>
             </div>
             <span class="s-alert-close"></span>
         </div>

--- a/client/s-alert-template.js
+++ b/client/s-alert-template.js
@@ -33,3 +33,10 @@ Template.sAlertContent.events({
         sAlert.close(this._id);
     }
 });
+
+Template.sAlertContent.helpers({
+    isHtml: function() {
+        var data = Template.currentData();
+        return data.html;
+    }    
+});

--- a/client/s-alert.js
+++ b/client/s-alert.js
@@ -48,7 +48,8 @@ sAlert = {
     settings: {
         effect: '',
         position: 'right-top',
-        timeout: 5000
+        timeout: 5000,
+        html: false
     },
     config: function (configObj) {
         var self = this;


### PR DESCRIPTION
Adding html option to alert (default html:false)

Meteor.startup(function () {

    sAlert.config({
        effect: '',
        position: 'top-right',
        timeout: 5000,
        html: true
    });

});
sAlert.info('First line &lt;br&gt; Second line'); 
