### PR TITLE
added local Data Object to enable reactivity

### DIFF
--- a/client/s-alert-collection.js
+++ b/client/s-alert-collection.js
@@ -2,3 +2,9 @@
 
 // only client side collections for now..
 sAlert.collection = new Mongo.Collection(null);
+// local observer to free copy of objects
+sAlert.collection.find().observe({
+    removed: function(oldDoc){
+        if(sAlert.messageData[oldDoc._id]) delete sAlert.messageData[oldDoc._id];
+    }
+});

--- a/client/s-alert-template.js
+++ b/client/s-alert-template.js
@@ -18,6 +18,9 @@ Template.sAlert.helpers({
         return sAlert.collection.find().map(function (alert, index) {
             positionTypeTop = alert.position && /top/g.test(alert.position);
             positionTypeBottom = alert.position && /bottom/g.test(alert.position);
+
+            if( sAlert.messageData[alert._id]) _.extend(alert,  sAlert.messageData[alert._id]);
+            
             if (alert.stack) {
                 // checking alert box height - needed to calculate position
                 docElement = document.createElement('div');

--- a/client/s-alert.js
+++ b/client/s-alert.js
@@ -10,7 +10,7 @@ var conditionSet = function (self, msg, condition, customSettings) {
         customSettings = {};
     }
     if (_.isObject(msg) && _.isString(condition)) {
-        settings = _.extend(settings, self.settings, msg, {condition: condition}, customSettings);
+        settings = _.extend(settings, self.settings, {message: msg.message}, {condition: condition}, customSettings);
     }
     if (_.isString(msg) && _.isString(condition)) {
         settings = _.extend(settings, self.settings, {message: msg}, {condition: condition}, customSettings);
@@ -21,6 +21,7 @@ var conditionSet = function (self, msg, condition, customSettings) {
     }
     if (_.isObject(settings) && !_.isEmpty(settings)) {
         sAlertId = sAlert.collection.insert(settings);
+        if(_.isObject(msg)) sAlert.messageData[sAlertId] = msg;
     }
     return sAlertId;
 };
@@ -55,6 +56,7 @@ sAlert = {
         stack: true,
         offset: 0 // in px - will be added to first alert (bottom or top - depends of the position in config)
     },
+    messageData : {},
     config: function (configObj) {
         var self = this;
         if (_.isObject(configObj)) {


### PR DESCRIPTION
Hey @juliancwirko,

first off thanks for your great work. This package is very nice. As i am using it to enable some guided learning - i have needed to pass reactive dependencies into a custom sAlert Template. So i have to do something like:
```javascript
    var myReactiveCounter = new ReactiveVar(0);
    sAlert.info({ message: this.messageInfo.text, counter: myReactiveCounter }, options);
```
But this does not work because the package is inserting all the msg Data into the local collection and ReactiveVar/Dependencies can not be serialized. 

For Client-Side usage it would be very nice to only write the Message and your Settings into the database and keep the helper data in an object. This PR, basically keeps a reference of the original object by inserting it with the sAlertId from your collection. The observer makes it possible to delete the reference again as the message is removed.

As i see this will not break any other features. I am using it in my project :+1: 
What do you think?

Cheers