### PR TITLE
Add onClose callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Meteor.startup(function () {
         //     limit: 3 // when fourth alert appears all previous ones are cleared
         // }
         offset: 0, // in px - will be added to first alert (bottom or top - depends of the position in config)
-        beep: false
+        beep: false,
         // examples:
         // beep: '/beep.mp3'  // or you can pass an object:
         // beep: {
@@ -57,6 +57,11 @@ Meteor.startup(function () {
         //     error: '/beep-error.mp3',
         //     success: '/beep-success.mp3',
         //     warning: '/beep-warning.mp3'
+        // }
+        onClose: _.noop //
+        // examples:
+        // onClose: function() {
+        //     /* Code here will be executed once the alert closes. */
         // }
     });
 
@@ -129,6 +134,14 @@ This particular error will be displayed in different way.
 #### Timeout:
 
 You can set up it in miliseconds or use the string `none`.
+
+#### Callback onClose:
+
+You can hook a callback when the alert closes.
+
+```js
+sAlert.success('Your message', {onClose: function() {console.log('closing alert...');}});
+```
 
 #### HTML tags
 

--- a/README.md
+++ b/README.md
@@ -137,10 +137,31 @@ You can set up it in miliseconds or use the string `none`.
 
 #### Callback onClose:
 
-You can hook a callback when the alert closes.
+You can hook a callback to be invoked when the alert closes. This callback will be invoked when the default timeout closes the alert.
 
 ```js
 sAlert.success('Your message', {onClose: function() {console.log('closing alert...');}});
+```
+
+If `timeout` is set specifically, it respects the setting.
+
+```js
+sAlert.success('Your message', {timeout: 1000, onClose: function() {console.log('closing alert in 1000ms...');}});
+```
+
+The callback will also be invoked if you specifically close the alert.
+
+```js
+var sAlertId = sAlert.success('Your message', {onClose: function() {console.log('closing alert...');}});
+sAlert.close(sAlertId);
+```
+
+It applies for `closeAll` as well.
+
+```js
+sAlert.success('Your message one', {onClose: function() {console.log('closing alert one...');}});
+sAlert.success('Your message two', {onClose: function() {console.log('closing alert two...');}});
+sAlert.closeAll();
 ```
 
 #### HTML tags

--- a/tests/s-alert-test.js
+++ b/tests/s-alert-test.js
@@ -372,3 +372,119 @@ describe('sAlert with stacking', function () {
         Blaze.remove(renderedView2);
     });
 });
+
+describe('sAlert callback onClose by close and closeAll functions', function () {
+    var renderedView1;
+    var renderedView2;
+    var renderedView3;
+    var sAlertId1;
+    var sAlertId2;
+    var sAlertId3;
+    var isClosed1;
+    var isClosed2;
+    var isClosed3;
+    before(function () {
+        sAlertId1 = sAlert.success('Test onClose callback...', {timeout: 'none', onClose: function() {isClosed1 = true;}});
+        renderedView1 = sAlertRender();
+        sAlertId2 = sAlert.success('Test onClose callback...', {timeout: 'none', onClose: function() {isClosed2 = true;}});
+        renderedView2 = sAlertRender();
+        sAlertId3 = sAlert.success('Test onClose callback...', {timeout: 'none', onClose: function() {isClosed3 = true;}});
+        renderedView3 = sAlertRender();
+    });
+    it('should get called when specifically closing the alert.', function () {
+        sAlert.close(sAlertId1);
+        chai.expect(isClosed1).to.be.true;
+        chai.expect(isClosed2).to.be.undefined;
+        chai.expect(isClosed3).to.be.undefined;
+    });
+    it('should get called when specifically closing all alerts..', function () {
+        sAlert.closeAll();
+        chai.expect(isClosed1).to.be.true;
+        chai.expect(isClosed2).to.be.true;
+        chai.expect(isClosed3).to.be.true;
+    });
+    after(function () {
+        sAlert.closeAll();
+        Blaze.remove(renderedView1);
+        Blaze.remove(renderedView2);
+        Blaze.remove(renderedView3);
+    });
+});
+
+describe('sAlert callback onClose without timeout param', function () {
+    var renderedView;
+    var sAlertId;
+    var isClosed;
+    before(function (done) {
+        this.timeout(sAlert.settings.timeout + 1000 );
+        sAlertId = sAlert.success('Test onClose callback...', {onClose: function() {isClosed = true; done();}});
+        renderedView = sAlertRender();
+    });
+    it('should get called when the default timeout closes the alert.', function (done) {
+        chai.expect(isClosed).to.be.true;
+        done();
+    });
+    after(function () {
+        sAlert.closeAll();
+        Blaze.remove(renderedView);
+    });
+});
+
+describe('sAlert onClose callback with timeout param', function () {
+    var renderedView;
+    var sAlertId;
+    var isClosed;
+    before(function () {
+        sAlertId = sAlert.success('Test onClose callback...', {timeout: 'none', onClose: function() {isClosed = true;}});
+        renderedView = sAlertRender();
+    });
+    it('should not get called with infinite timeout', function () {
+        chai.expect(isClosed).to.be.undefined;
+    });
+    after(function () {
+        sAlert.closeAll();
+        Blaze.remove(renderedView);
+    });
+});
+
+describe('sAlert onClose callback with 1000ms timeout param', function () {
+    var renderedView;
+    var sAlertId;
+    var isClosed;
+    before(function (done) {
+        sAlertId = sAlert.success('Test onClose callback...', {timeout: 1000, onClose: function() {isClosed = true;}});
+        renderedView = sAlertRender();
+        Meteor.setTimeout(function () {
+            done();
+        }, 1500);
+    });
+    it('should get called after 1000ms timeout', function (done) {
+        chai.expect(isClosed).to.be.true;
+        done();
+    });
+    after(function () {
+        sAlert.closeAll();
+        Blaze.remove(renderedView);
+    });
+});
+
+describe('sAlert onClose callback with 1800ms timeout param', function () {
+    var renderedView;
+    var sAlertId;
+    var isClosed;
+    before(function (done) {
+        sAlertId = sAlert.success('Test onClose callback...', {timeout: 1800, onClose: function() {isClosed = true;}});
+        renderedView = sAlertRender();
+        Meteor.setTimeout(function () {
+            done();
+        }, 1000);
+    });
+    it('should not get called before 1800ms timeout', function (done) {
+        chai.expect(isClosed).to.be.undefined;
+        done();
+    });
+    after(function () {
+        sAlert.closeAll();
+        Blaze.remove(renderedView);
+    });
+});


### PR DESCRIPTION
I found myself want to get notified when the alert closes. It can be accomplished, but this added setting could be neat.

```js
sAlert.config({
    effect: '',
    position: 'top-right',
    ...
    timeout: 5000,
    onClose: function() { /* to be run */ }
});
```

Supply test cases as well.