### PR TITLE
Fix mystic error with 'condition' field.

### DIFF
--- a/client/s-alert-template.html
+++ b/client/s-alert-template.html
@@ -17,7 +17,7 @@
     {{#if ../template}}
         {{> Template.dynamic template=../template data=this}}
     {{else}}
-        <div class="s-alert-box s-alert-{{condition}} s-alert-{{position}} {{#if effect}}s-alert-is-effect s-alert-effect-{{effect}}{{/if}} s-alert-show" id="{{_id}}" style="{{boxPosition}}">
+        <div class="s-alert-box s-alert-{{level}} s-alert-{{position}} {{#if effect}}s-alert-is-effect s-alert-effect-{{effect}}{{/if}} s-alert-show" id="{{_id}}" style="{{boxPosition}}">
             <div class="s-alert-box-inner">
                 <p>{{#if isHtml}}{{{message}}}{{else}}{{message}}{{/if}}</p>
             </div>

--- a/client/s-alert-template.js
+++ b/client/s-alert-template.js
@@ -65,6 +65,7 @@ var getAlertData = function (currentData, sAlertPosition) {
             // checking alert box height - needed to calculate position
             docElement = document.createElement('div');
             $(docElement).addClass('s-alert-box-height');
+            alert.level = alert.condition;
             if (_.isString(templateOverwrite)) {
                 sAlertBoxHTML = Blaze.toHTMLWithData(Template[templateOverwrite], alert);
             } else {

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
     'summary': 'Simple and fancy notifications / alerts / errors for Meteor',
-    'version': '3.2.0',
+    'version': '3.1.3_1',
     'git': 'https://github.com/juliancwirko/meteor-s-alert.git',
     'name': 'juliancwirko:s-alert'
 });


### PR DESCRIPTION
Issue:
Popups look non-styled because class "s-alert-{{condition}}" has the undefined variable.

I've spent two hours debugging this Blaze template but I still can't explain why "condition" field had no value (other fields like "effect" had!). Probably the field plays a special role for Blaze.

Solution:
I just created an alias for the field and it helped me! 
